### PR TITLE
Added mutex to prevent cross-talk on console.

### DIFF
--- a/include/ILogger.hpp
+++ b/include/ILogger.hpp
@@ -18,12 +18,14 @@
  ***************************/
 
 #include <exception>
+#include <mutex>
 #include <sstream>
 #include <string>
 
 namespace logpp {
 
     using std::exception;
+    using std::mutex;
 	using std::string;
     using std::stringstream;
 
@@ -236,7 +238,16 @@ namespace logpp {
 			 */
 			string getLogBufferAsString() { return getLogBuffer().str(); }
 
+            /**
+             * @brief Get the Write Mutex object
+             * 
+             * @return mutex& A reference to the mutex object.
+             */
+            mutex& getWriteMutex() { return *_writeMutex; }
+
 	    private:
+            static mutex* _writeMutex; ///!< Lock me before writing!
+
             string          _appName;
             string          _className;
             string          _customFlare;

--- a/src/ConsoleLogger.cpp
+++ b/src/ConsoleLogger.cpp
@@ -61,6 +61,7 @@ namespace logpp {
         using std::cout;
         using std::endl;
 
+        getWriteMutex().lock();
         // TODO: Implement functionality where bad logs are output to cerr if desired.
         // This will require overriding logMessage()
         auto output = getLogBufferAsString();
@@ -72,6 +73,7 @@ namespace logpp {
         } else cout << output;
         
         clearStringStream(getLogBuffer());
+        getWriteMutex().unlock();
     }
 
     /**
@@ -92,13 +94,18 @@ namespace logpp {
         if (_logToFile && _fileLogger != nullptr)
             _fileLogger->logMessage(level, msg);
 
+        getWriteMutex().lock();
         if (outputBadLogsToStderr() && isBadLog(level)) {
             // Bypass log buffer and print directly to stderr.
             if (*msg.end() == '\n') {
                 cerr << msg;
             } else cerr << msg << endl;
+
+            getWriteMutex().unlock();
             return;
         }
+        getWriteMutex().unlock();
+
         ILogger::logMessage(level, msg);
     }
 

--- a/src/ILogger.cpp
+++ b/src/ILogger.cpp
@@ -68,7 +68,7 @@ namespace logpp {
         this->_logName = logName;
         this->_maxLoggingLevel = maxLevel;
         this->_dateFormatString = "%Y.%m.%d";
-        this->_timeFormatString = "%H:%M";
+        this->_timeFormatString = "%H:%M:%S";
         this->_dateTimeFormatString = formatString("%s %s", _dateFormatString.c_str(), _timeFormatString.c_str());
 
         // Buffer init

--- a/src/ILogger.cpp
+++ b/src/ILogger.cpp
@@ -53,6 +53,8 @@ namespace logpp {
     string ILogger::LOG_FMT_APPNAME = 	"${appname}"; 	// ${appname} => if the application's name was set, output that
     string ILogger::LOG_FMT_CUSTOM = 	"${custom}"; 	// ${custom} => this allows for some custom flare to be added to log outputs
 
+    mutex* ILogger::_writeMutex = new mutex();
+
     // PROTECTED IMPLEMENTATION
 
     /**
@@ -172,6 +174,7 @@ namespace logpp {
      * @param msg The (formatted) message to output.
      */
     void ILogger::logMessage(LogLevel level, string msg) {
+        getWriteMutex().lock();
         if (msg.empty()) return;
 
         using std::endl;
@@ -180,6 +183,7 @@ namespace logpp {
             _logBuffer << msg;
         } else _logBuffer << msg << endl;
 
+        getWriteMutex().unlock();
         // Now check if we need to flush
         if (isBadLog(level) || (getMaxBufferSize() == 0 || getBufferSize() >= getMaxBufferSize()) || flushBufferAfterWrite()) {
             flushBuffer();


### PR DESCRIPTION
# Added mutex to prevent cross-talk


## Applies to version: 0.0.1

## Brief Description

I noticed an issue while using the logger w/ multi-threaded applications, that console outputs were sometimes mixed up. I added a static mutex object in the base class which is now locked and unlocked accordingly. I'll further test this, but the change seems stable.

