### PR TITLE
Added trace logging for debugging memory leaks w/o special applications.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_compile_options(
 ###
 include_directories(
     include/ # This is the main include directory
+    include/memory # For overloaded new and delete operators for debugging memleaks
 )
 
 ###
@@ -71,4 +72,4 @@ endif()
 ###
 # Export header files
 ###
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC include include/memory)

--- a/include/LogExtensions.hpp
+++ b/include/LogExtensions.hpp
@@ -161,6 +161,14 @@ namespace logpp {
         stream.clear();
     }
 
+    /**
+     * @brief Gets the base name of a path (may be a file or directory).
+     * 
+     * @param path The path to evaluate.
+     * @return string The base name of the path.
+     */
+    inline string getBaseName(string const &path) { return path.substr(path.find_last_of("/\\") + 1); }
+
 }
 
 #endif // LIBLOGPP_EXTENSIONS_HPP

--- a/include/memory_allocation/LeakDetection.hpp
+++ b/include/memory_allocation/LeakDetection.hpp
@@ -1,0 +1,66 @@
+/**
+ * @file LeakDetection.hpp
+ * @author Simon Cahill (simon@h3lix.de)
+ * @brief Contains a simple override for new and delete, which can be used to detect and debug memory leaks.
+ * @version 0.1
+ * @date 2020-01-29
+ * 
+ * @copyright Copyright (c) 2020
+ * 
+ */
+
+#ifndef LOGPP_LEAKDETECTION_HPP
+#define LOGPP_LEAKDETECTION_HPP
+
+#include "ConsoleLogger.hpp"
+
+#include <string>
+
+using std::string;
+namespace logpp { namespace memory {
+
+
+    /**
+     * @brief Very simple class which outputs memory allocations/deallocations to console.
+     */
+    class LeakLogger {
+        public:
+            static LeakLogger& getInstance() {
+                return  (_instance == nullptr) ?
+                       *(_instance = new LeakLogger()) :
+                       * _instance;
+            }
+
+            ~LeakLogger() {
+                delete _instance;
+                delete _consoleLogger;
+            }
+
+        public: // +++ Logging +++
+            void allocatedMemory(const size_t bytes, const string file, const int32_t line) {
+                _consoleLogger->trace(formatString("Allocated memory (%d Bytes) in %s:%d!", bytes, getBaseName(file).c_str(), line));
+            }
+
+            void deallocatedMemory(const string file, const int32_t line) {
+                _consoleLogger->trace(formatString("Deallocated memory in %s:%d!", getBaseName(file).c_str(), line));
+            }
+
+        private:
+            LeakLogger(): _consoleLogger(new ConsoleLogger("Memory Allocation", LOGLEVEL_MAXVALUE, true, 0, true)) { }
+
+        private:
+            ConsoleLogger* _consoleLogger = nullptr;
+
+            static LeakLogger* _instance;
+    };
+
+} /* memory */ } /* logpp */
+
+void* operator new(const size_t, const string, const int32_t);
+void* operator new[](const size_t, const string, const int32_t);
+void operator delete(void*, const string, const int32_t);
+void operator delete[](void*, const string, const int32_t);
+#define DEBUG_NEW new(__FILE__, __LINE__)
+//#define new DEBUG_NEW
+#define DEBUG_DELETE delete(__FILE__, __LINE__)
+#endif // LOGPP_LEAKDETECTION_HPP

--- a/src/memory_allocation/LeakDetection.cpp
+++ b/src/memory_allocation/LeakDetection.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file LeakDetection.cpp
+ * @author Simon Cahill (simon@h3lix.de)
+ * @brief Contains the implementation of the LeakDetection header.
+ * @version 0.1
+ * @date 2020-01-29
+ * 
+ * @copyright Copyright (c) 2020
+ */
+
+#include "memory_allocation/LeakDetection.hpp"
+
+#include <cstdio>
+
+namespace logpp { namespace memory {
+
+    LeakLogger* LeakLogger::_instance = nullptr;
+
+} /* memory */ } /* logpp */
+
+void* operator new(const std::size_t size, const string file, const int32_t line) {
+    logpp::memory::LeakLogger::getInstance().allocatedMemory(size, file, line);
+    return operator new(size);
+}
+
+void* operator new[](const std::size_t size, const string file, const int32_t line) {
+    logpp::memory::LeakLogger::getInstance().allocatedMemory(size, file, line);
+    return operator new[](size);
+}
+
+void operator delete(void* mem, const string file, const int32_t line) {
+    logpp::memory::LeakLogger::getInstance().deallocatedMemory(file, line);
+    operator delete(mem);
+}
+
+void operator delete[](void* mem, const string file, const int32_t line) {
+    logpp::memory::LeakLogger::getInstance().deallocatedMemory(file, line);
+    operator delete(mem);
+}


### PR DESCRIPTION
# Added trace logging for debugging memory leaks w/o special applications.

## Applies to version: 0.0.1

## Brief Description

This pull request contains some overloaded operators and a new object which allow basic debugging of memory leaks in C++ applications.
This is useful when working with embedded systems where popular applications such as Valgrind cannot be used, due to system constraints.