### PR TITLE
Use string::back instead of *msg.end()

### DIFF
--- a/src/ConsoleLogger.cpp
+++ b/src/ConsoleLogger.cpp
@@ -111,7 +111,7 @@ namespace logpp {
         getWriteMutex().lock();
         if (outputBadLogsToStderr() && isBadLog(level)) {
             // Bypass log buffer and print directly to stderr.
-            if (*msg.end() == '\n') {
+            if (msg.back() == '\n') {
                 cerr << msg;
             } else cerr << msg << endl;
 


### PR DESCRIPTION
# Use string::back() instead of string::end()

## Applies to version: 1.0.0

## Brief Description

Bug in source code detected where *msg.end() was used.
This is now changed to msg.back().
TODO: Change in other files?

