### PR TITLE
Potentially fixed a bug where an extra new line was added to log files

### DIFF
--- a/src/FileLogger.cpp
+++ b/src/FileLogger.cpp
@@ -86,7 +86,11 @@ namespace logpp {
     void FileLogger::logMessage(LogLevel level, string msg) {
         if (level > getCurrentMaxLogLevel()) return;
 
-        getLogBuffer() << msg << endl; // Add message to buffer
+        getLogBuffer() << msg;
+        if (msg.back() != '\n' || msg.back() != '\r') {
+            // Add the missing line feed
+            getLogBuffer() << getOsNewLineChar();
+        }
 
         // Now check if we need to flush
         if (isBadLog(level) || (getMaxBufferSize() == 0 || getBufferSize() >= getMaxBufferSize()) || flushBufferAfterWrite()) {


### PR DESCRIPTION
Potentially fixed a bug where an extra new line was added to log files.
This issue does not appear in the ConsoleLogger, and doesn't appear when only using the FileLogger.

When using the ConsoleLogger with its embedded FileLogger, ConsoleLogger adds a new line to logs where necessary, and FileLogger unconditionally added this extra new line, too.