### PR TITLE
Feat/use std filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,17 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # This is the part where you get to decide whether you
 # want a static or shared library
 ###
-set(logpp_BUILD_STATIC True)
+if (NOT logpp_BUILD_SHARED)
+    set(logpp_BUILD_STATIC True)
+else()
+    set(logpp_BUILD_STATIC False)
+endif()
+
+if (logpp_USE_FSTAT STREQUAL "ON")
+    add_definitions(
+        -Dlogpp_USE_FSTAT
+    )
+endif()
 
 ###
 # Set compiler flags


### PR DESCRIPTION
Updated fileExists and fileSize methods in FileLogger to use std::filesystem.
C++14 is the lowest supported standard by liblogpp, as such, unless logpp_USE_FSTAT=ON is passed to cmake, liblogpp will now use the filesystem library provided with stdc++. For C++14 the experimental/filesystem will be used.

