### PR TITLE
Updated all required params to be const or const ref

### DIFF
--- a/include/ConsoleLogger.hpp
+++ b/include/ConsoleLogger.hpp
@@ -20,11 +20,11 @@ namespace logpp {
      */
     class ConsoleLogger: public ILogger {
         public:
-            ConsoleLogger(string logName, LogLevel maxLogLevel, bool outputBadLogsToStderr, 
-                          uint32_t bufferSize, bool flushBufferAfterWrite); ///!< Object constructor.
-            ConsoleLogger(string logName, LogLevel maxLogLevel, bool outputBadLogsToStderr,
-                          uint32_t bufferSize, bool flushBufferAfterWrite, bool logToFile, string logPath,
-                          uint32_t maxFileSize); ///!< Object constructor.
+            ConsoleLogger(const string& logName, const LogLevel maxLogLevel, const bool outputBadLogsToStderr, 
+                          const uint32_t bufferSize, const bool flushBufferAfterWrite); ///!< Object constructor.
+            ConsoleLogger(const string& logName, const LogLevel maxLogLevel, const bool outputBadLogsToStderr,
+                          const uint32_t bufferSize, const bool flushBufferAfterWrite, const bool logToFile, const string& logPath,
+                          const uint32_t maxFileSize); ///!< Object constructor.
             virtual ~ConsoleLogger(); ///!< Virtual destructor.
             
             /**
@@ -44,7 +44,7 @@ namespace logpp {
             bool outputDebugLogsToStderr() const { return this->_outputDebugToStderr; }
 
             virtual void flushBuffer() override; ///!< Flushes the underlying buffer.
-            virtual void logMessage(LogLevel level, string msg) override; ///!< Logs a message to the console.
+            virtual void logMessage(const LogLevel level, const string& msg) override; ///!< Logs a message to the console.
             
             /**
              * @brief Sets a value indicating whether to output bad logs to std err.
@@ -79,7 +79,7 @@ namespace logpp {
              *
              * @return Returns the entire formatted message so it may be used in a function call.
              */
-            virtual string formatLogMessage(string& msg, LogLevel lvl, string func = "", int32_t line = -1, exception* except = nullptr) override;
+            virtual string formatLogMessage(const string& msg, LogLevel lvl, const string& func = "", const int32_t line = -1, const exception* except = nullptr) override;
 
         private:
             bool _colourLogLevels;

--- a/include/FileLogger.hpp
+++ b/include/FileLogger.hpp
@@ -22,11 +22,11 @@ namespace logpp {
         public:
             static const uint32_t DEFAULT_MAX_LOG_FILES;
 
-            FileLogger(string logName, LogLevel maxLogLevel, string filename, uint32_t bufferSize, 
-                       uint32_t maxFileSizeInMiB, bool flushBufferAfterWrite, bool createFile = false); ///!< object constructor
+            FileLogger(const string& logName, const LogLevel maxLogLevel, const string& filename, const uint32_t bufferSize, 
+                       const uint32_t maxFileSizeInMiB, const bool flushBufferAfterWrite, const bool createFile = false); ///!< object constructor
             virtual ~FileLogger(); ///!< virtual destructor
 
-            virtual void logMessage(LogLevel level, string msg) override;
+            virtual void logMessage(const LogLevel level, const string& msg) override;
 
             virtual FileLogger& setMaxFileCount(const uint32_t maxFileCount = DEFAULT_MAX_LOG_FILES) { _maxFileCount = maxFileCount; return *this; }
 
@@ -36,8 +36,8 @@ namespace logpp {
             uint32_t _maxFileSize; ///!< max size of log file in MB
             uint32_t _maxFileCount; ///!< The maximum amount of files logpp is allowed to create before overwriting the files in a loop
 
-            bool fileExists(string filename);
-            uint32_t fileSize(string filename);
+            bool fileExists(const string& filename);
+            uint32_t fileSize(const string& filename);
             virtual void flushBuffer() override; ///!< Flushes the underlying buffer.
             uint32_t maxFileSizeInMiB() const { return _maxFileSize; } ///!< getter for _maxFileSize
             void maxFileSize(const uint32_t maxFileSize) { _maxFileSize = maxFileSize; } ///!< setter for _maxFileSize

--- a/include/ILogger.hpp
+++ b/include/ILogger.hpp
@@ -49,17 +49,17 @@ namespace logpp {
             // This is especially handy if you're logging to one large file where different programs'
             // log messages are saved.
             //==========================================================================================
-            static string LOG_FMT_DATE; ///! ${date} => the current date w/ the set date format
-            static string LOG_FMT_TIME; ///! ${time} => the current time w/ the set time format
-            static string LOG_FMT_DATETIME; ///! ${datetime} => the current time and date w/ the set formats
-            static string LOG_FMT_LOGLVL; ///! ${llevel} => the log level of the current message
-            static string LOG_FMT_MSG; ///! ${lmsg} => the actual log message
-            static string LOG_FMT_FUNC; ///! ${func} => if the current function was set via param, output that
-            static string LOG_FMT_LINE; ///! ${lineno} => if the current line number was set via param, output that
-            static string LOG_FMT_CLASS; ///! ${class} => if the class name was set, output that
-            static string LOG_FMT_EXCEPT; ///! ${except} => if an exception was passed, output that
-            static string LOG_FMT_APPNAME; ///! ${appname} => if the application's name was set, output that
-            static string LOG_FMT_CUSTOM; ///! ${custom} => this allows for some custom flare to be added to log outputs
+            static const string LOG_FMT_DATE; ///! ${date} => the current date w/ the set date format
+            static const string LOG_FMT_TIME; ///! ${time} => the current time w/ the set time format
+            static const string LOG_FMT_DATETIME; ///! ${datetime} => the current time and date w/ the set formats
+            static const string LOG_FMT_LOGLVL; ///! ${llevel} => the log level of the current message
+            static const string LOG_FMT_MSG; ///! ${lmsg} => the actual log message
+            static const string LOG_FMT_FUNC; ///! ${func} => if the current function was set via param, output that
+            static const string LOG_FMT_LINE; ///! ${lineno} => if the current line number was set via param, output that
+            static const string LOG_FMT_CLASS; ///! ${class} => if the class name was set, output that
+            static const string LOG_FMT_EXCEPT; ///! ${except} => if an exception was passed, output that
+            static const string LOG_FMT_APPNAME; ///! ${appname} => if the application's name was set, output that
+            static const string LOG_FMT_CUSTOM; ///! ${custom} => this allows for some custom flare to be added to log outputs
 
 	    public:
             virtual ~ILogger(); ///!< Virtual destructor
@@ -70,63 +70,63 @@ namespace logpp {
              * @return true If the buffer should be flushed after each write.
              * @return false Otherwise.
              */
-            bool flushBufferAfterWrite() { return this->_flushBufferAfterWrite; }
+            bool flushBufferAfterWrite() const { return this->_flushBufferAfterWrite; }
 
             /**
              * @brief Gets the current max log level for this instance.
              */
-            LogLevel getCurrentMaxLogLevel() { return this->_maxLoggingLevel; }
+            LogLevel getCurrentMaxLogLevel() const { return this->_maxLoggingLevel; }
 
             /**
              * @brief Gets the name of the application that was set in this logger instance.
              */
-            string getCurrentApplicationName() { return this->_appName; }
+            string getCurrentApplicationName() const { return this->_appName; }
 
             /**
              * @brief Gets the name of the class using this logger. Only handy if multiple loggers are used.
              */
-            string getCurrentClassName() { return this->_className; }
+            string getCurrentClassName() const { return this->_className; }
 
             /**
              * @brief Gets the custom flare set to use when logging.
              */
-            string getCurrentCustomFlare() { return this->_customFlare; }
+            string getCurrentCustomFlare() const { return this->_customFlare; }
 
             /**
              * @brief Gets the string used to format log outputs.
              */
-            string getCurrentLoggerFormat() { return this->_loggerFormat; }
+            string getCurrentLoggerFormat() const { return this->_loggerFormat; }
 
             /**
              * @brief Gets the name of this logger.
              */
-            string getCurrentLoggerName() { return this->_logName; }
+            string getCurrentLoggerName() const { return this->_logName; }
 
             /**
              * @brief Gets the current date as per format rules.
              *
              * @return The current date as defined by _dateFormatString
              */
-            virtual string getCurrentDate();
+            virtual string getCurrentDate() const;
 
             /**
              * @brief Gets the current date as per format rules.
              *
              * @return The current date as defined by _dateTimeFormatString
              */
-            virtual string getCurrentDateTime();
+            virtual string getCurrentDateTime() const;
 
             /**
              * @brief Gets the newline char required for the operating system currently in use.
              */
-            virtual string getOsNewLineChar();
+            virtual string getOsNewLineChar() const;
 
             /**
              * @brief Gets the size of the string (in bytes) of the underlying buffer.
              *
              * @return The size (in bytes) of the underlying buffer.
              */
-            uint32_t getBufferSize() { return this->_logBuffer.str().size(); }
+            uint32_t getBufferSize() const { return this->_logBuffer.str().size(); }
 
             /**
              * @brief Gets the maximum size for the logger buffer.
@@ -135,14 +135,14 @@ namespace logpp {
              *
              * @return The maximum configured buffer size.
              */
-            uint32_t getMaxBufferSize() { return this->_maxBufferSize; }
+            uint32_t getMaxBufferSize() const { return this->_maxBufferSize; }
 
             /**
              * @brief Gets the current date as per format rules.
              *
              * @return The current date as defined by _timeFormatString
              */
-            virtual string getCurrentTime();
+            virtual string getCurrentTime() const;
 
             /**
              * @brief Formats an entire log message which may then be directly printed to any given (string) output.
@@ -155,7 +155,7 @@ namespace logpp {
              *
              * @return Returns the entire formatted message so it may be used in a function call.
              */
-            virtual string formatLogMessage(string& msg, LogLevel lvl, string func = "", int32_t line = -1, exception* except = nullptr);
+            virtual string formatLogMessage(const string& msg, const LogLevel lvl, const string& func = "", const int32_t line = -1, const exception* except = nullptr);
 
             /**
              * @brief Flushes the internal buffer; abstract.
@@ -165,70 +165,70 @@ namespace logpp {
             /**
              * @brief VIRTUAL - Logs a message.
              */
-            virtual void logMessage(LogLevel level, string msg);
+            virtual void logMessage(const LogLevel level, const string& msg);
 
             //////////////////////////////
             //      Log Shortcuts       //
             //////////////////////////////
-            virtual void debug(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging debug messages. Abstract.
-            virtual void error(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging error messages. Abstract.
-            virtual void fatal(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging fatal messages. Abstract.
-            virtual void info(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging info messages. Abstract.
-            virtual void ok(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging ok messages. Abstract.
-            virtual void trace(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging trace messages. Abstract.
-            virtual void warning(string msg, exception* except = nullptr, int32_t line = -1, string func = ""); ///!< A shortcut method for logging warning messages. Abstract.
+            virtual void debug(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging debug messages. Abstract.
+            virtual void error(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging error messages. Abstract.
+            virtual void fatal(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging fatal messages. Abstract.
+            virtual void info(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging info messages. Abstract.
+            virtual void ok(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging ok messages. Abstract.
+            virtual void trace(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging trace messages. Abstract.
+            virtual void warning(const string& msg, const exception* except = nullptr, const int32_t line = -1, const string& func = ""); ///!< A shortcut method for logging warning messages. Abstract.
             
             template<typename... Args>
-            void debugFmt(const string fmt, Args... args) { debug(formatString(fmt, args...)); }
+            void debugFmt(const string& fmt, Args... args) { debug(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void errorFmt(const string fmt, Args... args) { error(formatString(fmt, args...)); }
+            void errorFmt(const string& fmt, Args... args) { error(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void fatalFmt(const string fmt, Args... args) { fatal(formatString(fmt, args...)); }
+            void fatalFmt(const string& fmt, Args... args) { fatal(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void infoFmt(const string fmt, Args... args) { info(formatString(fmt, args...)); }
+            void infoFmt(const string& fmt, Args... args) { info(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void okFmt(const string fmt, Args... args) { ok(formatString(fmt, args...)); }
+            void okFmt(const string& fmt, Args... args) { ok(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void traceFmt(const string fmt, Args... args) { trace(formatString(fmt, args...)); }
+            void traceFmt(const string& fmt, Args... args) { trace(formatString(fmt, args...)); }
 
             template<typename... Args>
-            void warningFmt(const string fmt, Args... args) { warning(formatString(fmt, args...)); }
+            void warningFmt(const string& fmt, Args... args) { warning(formatString(fmt, args...)); }
 
 
             /**
              * @brief Sets the application name for this logger instance.
              */
-            void setCurrentApplicationName(string appName) { this->_appName = appName; }
+            void setCurrentApplicationName(const string& appName) { this->_appName = appName; }
 
             /**
              * @brief Sets the name of the class using this instance.
              */
-            void setCurrentClassName(string _className) { this->_className = _className; }
+            void setCurrentClassName(const string& _className) { this->_className = _className; }
 
             /**
              * @brief Sets the custom flare to use with this instance.
              */
-            void setCurrentCustomFlare(string _customFlare) { this->_customFlare = _customFlare; }
+            void setCurrentCustomFlare(const string& _customFlare) { this->_customFlare = _customFlare; }
 
             /**
              * @brief Sets the custom logger format. Default is default
              */
-            void setCurrentLoggerFormat(string loggerFormat = "[ ${date} ${time} ] [ ${llevel} ] ${lmsg}") { this->_loggerFormat = loggerFormat; }
+            void setCurrentLoggerFormat(const string& loggerFormat = "[ ${date} ${time} ] [ ${llevel} ] ${lmsg}") { this->_loggerFormat = loggerFormat; }
 
             /**
              * @brief Sets the custom name for this logger. If default, generates random ID.
              */
-            void setCurrentLoggerName(string logName = "") { this->_logName = logName; }
+            void setCurrentLoggerName(const string& logName = "") { this->_logName = logName; }
 
             /**
              * @brief Sets the current maximum log level.
              */
-            void setCurrentMaxLogLevel(LogLevel level = LogLevel::Error) { this->_maxLoggingLevel = level; }
+            void setCurrentMaxLogLevel(const LogLevel level = LogLevel::Error) { this->_maxLoggingLevel = level; }
 
             /**
              * @brief Sets a value indicating whether to flush the underlying buffer after each write.
@@ -246,10 +246,10 @@ namespace logpp {
              *
              * @param maxSize The maximum buffer size in bytes.
              */
-            void setMaxBufferSize(uint32_t maxSize) { this->_maxBufferSize = maxSize; }
+            void setMaxBufferSize(const uint32_t maxSize) { this->_maxBufferSize = maxSize; }
 
 	    protected:
-	        ILogger(string logName, LogLevel maxLevel, uint32_t bufferSize, bool flushBufferAfterWrite); ///!< Base constructor.
+	        ILogger(const string& logName, LogLevel maxLevel, uint32_t bufferSize, bool flushBufferAfterWrite); ///!< Base constructor.
 
             /**
              * @brief Gets a reference to the string stream used as a buffer.

--- a/src/ConsoleLogger.cpp
+++ b/src/ConsoleLogger.cpp
@@ -30,7 +30,7 @@ namespace logpp {
      * @param bufferSize The maximum buffer size before flushing.
      * @param flushBufferAfterWrite Indicates whether to flush the buffer after each write to it.
      */
-    ConsoleLogger::ConsoleLogger(string logName, LogLevel maxLogLevel, bool outputBadLogsToStderr, uint32_t bufferSize, bool flushBufferAfterWrite):
+    ConsoleLogger::ConsoleLogger(const string& logName, const LogLevel maxLogLevel, const bool outputBadLogsToStderr, const uint32_t bufferSize, const bool flushBufferAfterWrite):
     ILogger(logName, maxLogLevel, flushBufferAfterWrite, bufferSize), _fileLogger(nullptr), _logToFile(false), _colourLogLevels(true) {
         setOutputBadLogsToStderr(outputBadLogsToStderr);
     }
@@ -47,8 +47,8 @@ namespace logpp {
      * @param logPath The directory in which to create the log file(s).
      * @param maxFileSize The maximum log file size in MiB.
      */
-    ConsoleLogger::ConsoleLogger(string logName, LogLevel maxLogLevel, bool outputBadLogsToStderr, uint32_t bufferSize, bool flushBufferAfterWrite,
-                                 bool logToFile, string logPath, uint32_t maxFileSize): 
+    ConsoleLogger::ConsoleLogger(const string& logName, const LogLevel maxLogLevel, const bool outputBadLogsToStderr, const uint32_t bufferSize, const bool flushBufferAfterWrite,
+                                 const bool logToFile, const string& logPath, const uint32_t maxFileSize): 
     ConsoleLogger(logName, maxLogLevel, outputBadLogsToStderr, flushBufferAfterWrite, bufferSize) {
         this->_logToFile = logToFile;
         if (_logToFile) {
@@ -101,7 +101,7 @@ namespace logpp {
      * @param level The log level of the message.
      * @param msg The message to be output.
      */
-    void ConsoleLogger::logMessage(LogLevel level, string msg) {
+    void ConsoleLogger::logMessage(const LogLevel level, const string& msg) {
         using std::cerr;
         using std::endl;
 
@@ -135,7 +135,7 @@ namespace logpp {
      *
      * @param msg A reference to the message to be logged. This string will be modified!
      */
-    string ConsoleLogger::formatLogMessage(string& msg, LogLevel lvl, string func, int32_t line, exception* except) {
+    string ConsoleLogger::formatLogMessage(const string& msg, const LogLevel lvl, const string& func, const int32_t line, const exception* except) {
         // logFormat local class variable containing formatting
         if (getCurrentLoggerFormat().empty() || msg.empty()) {
             return msg;

--- a/src/FileLogger.cpp
+++ b/src/FileLogger.cpp
@@ -56,8 +56,8 @@ namespace logpp {
     * @param bufferSize The maximum buffer size before flushing.
     * @param flushBufferAfterWrite Indicates whether to flush the buffer after each write to it.
     */
-    FileLogger::FileLogger(string logName, LogLevel maxLogLevel, string filename, uint32_t bufferSize,
-                           uint32_t maxFileSize, bool flushBufferAfterWrite, bool createFileIfNotExists
+    FileLogger::FileLogger(const string& logName, const LogLevel maxLogLevel, const string& filename, const uint32_t bufferSize,
+                           const uint32_t maxFileSize, const bool flushBufferAfterWrite, const bool createFileIfNotExists
                           ): ILogger(logName, maxLogLevel, bufferSize, flushBufferAfterWrite),
                           _maxFileCount(DEFAULT_MAX_LOG_FILES), _maxFileSize(maxFileSize),
                           _filename(filename) {}
@@ -74,7 +74,7 @@ namespace logpp {
      *
      * @return true if file exists, false else 
      */
-    bool FileLogger::fileExists(string filename) {
+    bool FileLogger::fileExists(const string& filename) {
         #ifdef logpp_USE_FSTAT
         struct stat buffer;
         return (stat(filename.c_str (), &buffer) == 0);
@@ -90,7 +90,7 @@ namespace logpp {
      *
      * @return size of file in bytes
      */
-    uint32_t FileLogger::fileSize(string filename) {
+    uint32_t FileLogger::fileSize(const string& filename) {
         #ifdef logpp_USE_FSTAT
         struct stat buffer;
         stat(filename.c_str(), &buffer);
@@ -108,7 +108,7 @@ namespace logpp {
      * @param level The level of the current log.
      * @param msg The (formatted) message to output.
      */
-    void FileLogger::logMessage(LogLevel level, string msg) {
+    void FileLogger::logMessage(const LogLevel level, const string& msg) {
         if (level > getCurrentMaxLogLevel()) return;
 
         getLogBuffer() << msg;

--- a/src/ILogger.cpp
+++ b/src/ILogger.cpp
@@ -41,17 +41,17 @@ namespace logpp {
     // This is especially handy if you're logging to one large file where different programs'
     // log messages are saved.
     //==========================================================================================
-    string ILogger::LOG_FMT_DATE = 	    "${date}"; 	// ${date} => the current date w/ the set date format
-    string ILogger::LOG_FMT_TIME = 	    "${time}"; 	// ${time} => the current time w/ the set time format
-    string ILogger::LOG_FMT_DATETIME = 	"${datetime}"; 	// ${datetime} => the current time and date w/ the set formats
-    string ILogger::LOG_FMT_LOGLVL = 	"${llevel}"; 	// ${llevel} => the log level of the current message
-    string ILogger::LOG_FMT_MSG = 	    "${lmsg}"; 	// ${lmsg} => the actual log message
-    string ILogger::LOG_FMT_FUNC = 	    "${func}"; 	// ${func} => if the current function was set via param, output that
-    string ILogger::LOG_FMT_LINE = 	    "${lineno}"; 	// ${lineno} => if the current line number was set via param, output that
-    string ILogger::LOG_FMT_CLASS = 	"${class}"; 	// ${class} => if the class name was set, output that
-    string ILogger::LOG_FMT_EXCEPT = 	"${except}"; 	// ${except} => if an exception was passed, output that
-    string ILogger::LOG_FMT_APPNAME = 	"${appname}"; 	// ${appname} => if the application's name was set, output that
-    string ILogger::LOG_FMT_CUSTOM = 	"${custom}"; 	// ${custom} => this allows for some custom flare to be added to log outputs
+    const string ILogger::LOG_FMT_DATE = 	    "${date}"; 	// ${date} => the current date w/ the set date format
+    const string ILogger::LOG_FMT_TIME = 	    "${time}"; 	// ${time} => the current time w/ the set time format
+    const string ILogger::LOG_FMT_DATETIME = 	"${datetime}"; 	// ${datetime} => the current time and date w/ the set formats
+    const string ILogger::LOG_FMT_LOGLVL = 	"${llevel}"; 	// ${llevel} => the log level of the current message
+    const string ILogger::LOG_FMT_MSG = 	    "${lmsg}"; 	// ${lmsg} => the actual log message
+    const string ILogger::LOG_FMT_FUNC = 	    "${func}"; 	// ${func} => if the current function was set via param, output that
+    const string ILogger::LOG_FMT_LINE = 	    "${lineno}"; 	// ${lineno} => if the current line number was set via param, output that
+    const string ILogger::LOG_FMT_CLASS = 	"${class}"; 	// ${class} => if the class name was set, output that
+    const string ILogger::LOG_FMT_EXCEPT = 	"${except}"; 	// ${except} => if an exception was passed, output that
+    const string ILogger::LOG_FMT_APPNAME = 	"${appname}"; 	// ${appname} => if the application's name was set, output that
+    const string ILogger::LOG_FMT_CUSTOM = 	"${custom}"; 	// ${custom} => this allows for some custom flare to be added to log outputs
 
     mutex* ILogger::_writeMutex = new mutex();
 
@@ -66,7 +66,7 @@ namespace logpp {
      * @param bufferSize The maximum size of the underlying buffer.
      * @param flushBufferAfterWrite A value indicating whether to flush the buffer after each write.
      */
-    ILogger::ILogger(string logName, LogLevel maxLevel, uint32_t bufferSize, bool flushBufferAfterWrite) {
+    ILogger::ILogger(const string& logName, LogLevel maxLevel, uint32_t bufferSize, bool flushBufferAfterWrite) {
         this->_logName = logName;
         this->_maxLoggingLevel = maxLevel;
         this->_dateFormatString = "%Y.%m.%d";
@@ -96,7 +96,7 @@ namespace logpp {
      *
      * @param msg A reference to the message to be logged. This string will be modified!
      */
-    string ILogger::formatLogMessage(string& msg, LogLevel lvl, string func, int32_t line, exception* except) {
+    string ILogger::formatLogMessage(const string& msg, LogLevel lvl, const string& func, const int32_t line, const exception* except) {
         // logFormat local class variable containing formatting
         if (_loggerFormat.empty() || msg.empty()) {
             return msg;
@@ -128,7 +128,7 @@ namespace logpp {
      *
      * @return The current date as defined by _dateFormatString
      */
-    string ILogger::getCurrentDate() {
+    string ILogger::getCurrentDate() const {
         auto timeStruct = getCurrentLocalTime();
         string charBuffer;
 
@@ -142,7 +142,7 @@ namespace logpp {
      *
      * @return The current date as defined by _dateTimeFormatString
      */
-    string ILogger::getCurrentDateTime() {
+    string ILogger::getCurrentDateTime() const {
         auto timeStruct = getCurrentLocalTime();
         char charBuffer[128];
         
@@ -156,7 +156,7 @@ namespace logpp {
      *
      * @return The current date as defined by _timeFormatString
      */
-    string ILogger::getCurrentTime() {
+    string ILogger::getCurrentTime() const {
         auto timeStruct = getCurrentLocalTime();
         string charBuffer;
 
@@ -165,7 +165,7 @@ namespace logpp {
         return charBuffer;
     }
 
-    string ILogger::getOsNewLineChar() {
+    string ILogger::getOsNewLineChar() const {
         static string newLine = "";
 
         if (newLine.empty()) {
@@ -185,7 +185,7 @@ namespace logpp {
      * @param level The level of the current log.
      * @param msg The (formatted) message to output.
      */
-    void ILogger::logMessage(LogLevel level, string msg) {
+    void ILogger::logMessage(LogLevel level, const string& msg) {
         // Check if we're supposed to log anything or not
         if (level > this->_maxLoggingLevel) return;
 
@@ -215,7 +215,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::debug(string msg, exception* except, int32_t line, string func) {
+    void ILogger::debug(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Debug;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -228,7 +228,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::error(string msg, exception* except, int32_t line, string func) {
+    void ILogger::error(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Error;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -241,7 +241,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::fatal(string msg, exception* except, int32_t line, string func) {
+    void ILogger::fatal(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Fatal;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -254,7 +254,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::info(string msg, exception* except, int32_t line, string func) {
+    void ILogger::info(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Info;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -267,7 +267,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::ok(string msg, exception* except, int32_t line, string func) {
+    void ILogger::ok(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Ok;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -280,7 +280,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::trace(string msg, exception* except, int32_t line, string func) {
+    void ILogger::trace(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Trace;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }
@@ -293,7 +293,7 @@ namespace logpp {
      * @param line (Optional) The line at which the logger was called.
      * @param func (Optional) The function/method in which the logger was called.
      */
-    void ILogger::warning(string msg, exception* except, int32_t line, string func) {
+    void ILogger::warning(const string& msg, const exception* except, const int32_t line, const string& func) {
         auto level = LogLevel::Warning;
         logMessage(level, formatLogMessage(msg, level, func, line, except));
     }


### PR DESCRIPTION
Updated all (required) parameters to now be const or const ref. This should help prevent confusion and is generally considered best practice.